### PR TITLE
add the possibility to completly disable the viewpager-toolbar

### DIFF
--- a/materialviewpager/src/main/java/com/github/florent37/materialviewpager/MaterialViewPager.java
+++ b/materialviewpager/src/main/java/com/github/florent37/materialviewpager/MaterialViewPager.java
@@ -7,7 +7,6 @@ import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.v4.view.ViewPager;
-import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;

--- a/materialviewpager/src/main/java/com/github/florent37/materialviewpager/MaterialViewPager.java
+++ b/materialviewpager/src/main/java/com/github/florent37/materialviewpager/MaterialViewPager.java
@@ -7,6 +7,7 @@ import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.v4.view.ViewPager;
+import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
@@ -118,6 +119,8 @@ public class MaterialViewPager extends FrameLayout implements ViewPager.OnPageCh
         logoContainer = (ViewGroup) findViewById(R.id.logoContainer);
 
         mToolbar = (Toolbar) findViewById(R.id.toolbar);
+        if(settings.disableToolbar)
+            mToolbar.setVisibility(GONE);
         mViewPager = (ViewPager) findViewById(R.id.viewPager);
 
         mViewPager.addOnPageChangeListener(this);
@@ -223,6 +226,15 @@ public class MaterialViewPager extends FrameLayout implements ViewPager.OnPageCh
      */
     public PagerSlidingTabStrip getPagerTitleStrip() {
         return (PagerSlidingTabStrip) pagerTitleStripContainer.findViewById(R.id.materialviewpager_pagerTitleStrip);
+    }
+
+    /**
+     * Retrieve the displayed toolbar
+     *
+     * @return the displayed toolbar
+     */
+    public void setToolbar(Toolbar toolbar) {
+        mToolbar=toolbar;
     }
 
     /**

--- a/materialviewpager/src/main/java/com/github/florent37/materialviewpager/MaterialViewPagerSettings.java
+++ b/materialviewpager/src/main/java/com/github/florent37/materialviewpager/MaterialViewPagerSettings.java
@@ -39,6 +39,7 @@ public class MaterialViewPagerSettings implements Parcelable {
     protected boolean displayToolbarWhenSwipe;
     protected boolean toolbarTransparent;
     protected boolean animatedHeaderImage;
+    protected boolean disableToolbar;
 
     /**
      * Retrieve attributes from the MaterialViewPager
@@ -75,7 +76,7 @@ public class MaterialViewPagerSettings implements Parcelable {
             }
             {
                 parallaxHeaderFactor = styledAttrs.getFloat(R.styleable.MaterialViewPager_viewpager_parallaxHeaderFactor, 1.5f);
-                parallaxHeaderFactor = Math.max(parallaxHeaderFactor,1); //min=1
+                parallaxHeaderFactor = Math.max(parallaxHeaderFactor, 1); //min=1
             }
             {
                 hideToolbarAndTitle = styledAttrs.getBoolean(R.styleable.MaterialViewPager_viewpager_hideToolbarAndTitle, false);
@@ -92,6 +93,9 @@ public class MaterialViewPagerSettings implements Parcelable {
             }
             {
                 animatedHeaderImage = styledAttrs.getBoolean(R.styleable.MaterialViewPager_viewpager_animatedHeaderImage, true);
+            }
+            {
+                disableToolbar = styledAttrs.getBoolean(R.styleable.MaterialViewPager_viewpager_disableToolbar, false);
             }
             styledAttrs.recycle();
         } catch (Exception e) {

--- a/materialviewpager/src/main/res/values/attrs.xml
+++ b/materialviewpager/src/main/res/values/attrs.xml
@@ -17,6 +17,7 @@
         <attr name="viewpager_displayToolbarWhenSwipe" format="boolean"/>
         <attr name="viewpager_transparentToolbar" format="boolean"/>
         <attr name="viewpager_animatedHeaderImage" format="boolean"/>
+        <attr name="viewpager_disableToolbar" format="boolean"/>
 
     </declare-styleable>
 


### PR DESCRIPTION
Background: I use the viewpager as a single-fragment within a AppCompatActivity. In this activity there is already an ActionBar with a toolbar defined. 
I needed to completely disable/hide the toolbar offered with the viewpager.

Usage: Just set attribute `app:viewpager_disableToolbar="true"` to the viewpager-xml. Default value is, for sure, `false`.

Hint: there might be some problems if `app:viewpager_hideLogoWithFade` and `app:viewpager_hideToolbarAndTitle` are set to `false`. Better set them to `true`.