### PR TITLE
Fix what seems to be a mistake in fromColorResAndDrawable

### DIFF
--- a/materialviewpager/src/main/java/com/github/florent37/materialviewpager/header/HeaderDesign.java
+++ b/materialviewpager/src/main/java/com/github/florent37/materialviewpager/header/HeaderDesign.java
@@ -37,10 +37,10 @@ public class HeaderDesign {
         return headerDesign;
     }
 
-    public static HeaderDesign fromColorResAndDrawable(@ColorRes int colorRes, String imageUrl) {
+    public static HeaderDesign fromColorResAndDrawable(@ColorRes int colorRes, Drawable drawable) {
         HeaderDesign headerDesign = new HeaderDesign();
         headerDesign.colorRes = colorRes;
-        headerDesign.imageUrl = imageUrl;
+        headerDesign.drawable = drawable;
         return headerDesign;
     }
 


### PR DESCRIPTION
Based off the name of the function, it seems that `fromColorResAndDrawable` should take in a `Drawable` object, not a `String` imageUrl.