### PR TITLE
Upgrade glide dependency to 4.0.0

### DIFF
--- a/materialviewpager/build.gradle
+++ b/materialviewpager/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 
     compile 'com.flaviofaria:kenburnsview:1.0.7'
     compile 'com.jpardogo.materialtabstrip:library:1.1.0'
-    compile 'com.github.bumptech.glide:glide:3.7.0'
+    compile 'com.github.bumptech.glide:glide:4.0.0'
 }
 
 ext {

--- a/materialviewpager/src/main/java/com/github/florent37/materialviewpager/header/MaterialViewPagerImageHelper.java
+++ b/materialviewpager/src/main/java/com/github/florent37/materialviewpager/header/MaterialViewPagerImageHelper.java
@@ -2,6 +2,7 @@ package com.github.florent37.materialviewpager.header;
 
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
+import android.support.annotation.Nullable;
 import android.support.v4.view.ViewCompat;
 import android.support.v4.view.ViewPropertyAnimatorListenerAdapter;
 import android.view.View;
@@ -10,8 +11,10 @@ import android.view.animation.DecelerateInterpolator;
 import android.widget.ImageView;
 
 import com.bumptech.glide.Glide;
-import com.bumptech.glide.load.resource.drawable.GlideDrawable;
+import com.bumptech.glide.load.DataSource;
+import com.bumptech.glide.load.engine.GlideException;
 import com.bumptech.glide.request.RequestListener;
+import com.bumptech.glide.request.RequestOptions;
 import com.bumptech.glide.request.target.Target;
 import com.github.florent37.materialviewpager.MaterialViewPager;
 
@@ -40,15 +43,15 @@ public class MaterialViewPagerImageHelper {
 
                 //change the image when alpha=0
                 Glide.with(imageView.getContext()).load(urlImage)
-                    .centerCrop()
-                    .listener(new RequestListener<String, GlideDrawable>() {
+                    .apply(new RequestOptions().centerCrop())
+                    .listener(new RequestListener<Drawable>() {
                         @Override
-                        public boolean onException(Exception e, String model, Target<GlideDrawable> target, boolean isFirstResource) {
+                        public boolean onLoadFailed(@Nullable GlideException e, Object model, Target<Drawable> target, boolean isFirstResource) {
                             return false;
                         }
 
                         @Override
-                        public boolean onResourceReady(GlideDrawable resource, String model, Target<GlideDrawable> target, boolean isFromMemoryCache, boolean isFirstResource) {
+                        public boolean onResourceReady(Drawable resource, Object model, Target<Drawable> target, DataSource dataSource, boolean isFirstResource) {
                             //then fade to alpha=1
                             fadeIn(viewToAnimate, alpha, fadeDuration, new ViewPropertyAnimatorListenerAdapter());
                             if (imageLoadListener != null) {


### PR DESCRIPTION
Upgrading to glide 4.0 in application causes glide dependent classes to break since glide 4.0 is not backwards compatible. I imagine after accepting pull request this will now be an issue for everyone still using glide version < 4.0. Perhaps there is a better way of managing version mismatch where both versions of glide can co-exist and app compiles with its own glide version whereas library compiles against its own glide version.